### PR TITLE
[OWL-512] Set `Endpoint` by `Hostname`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# (This document is deprecated)
+
 # nqm
 
 The module of network quality measurement

--- a/data.go
+++ b/data.go
@@ -48,7 +48,7 @@ func marshalFpingRowIntoJSON(row []string, target model.NqmTarget) []ParamToAgen
  *     Transmission Time - float64
  */
 func marshalJSON(target model.NqmTarget, metric string, value interface{}) ParamToAgent {
-	endpoint := GetGeneralConfig().ConnectionID
+	endpoint := GetGeneralConfig().Hostname
 	counterType := "GAUGE"
 	tags := "nqm-agent-isp=" + GetGeneralConfig().ISP +
 		",nqm-agent-province=" + GetGeneralConfig().Province +


### PR DESCRIPTION
Instead of using the `ConnectionID` as the value of `Endpoint`, we use the `Hostname` now.
