### PR TITLE
[OWL-663] Ensure single instance of `query()`

### DIFF
--- a/cfg.go
+++ b/cfg.go
@@ -111,6 +111,10 @@ func getHostname() string {
 	if err != nil {
 		log.Fatalln("os.Hostname() ERROR:", err)
 	}
+	// hostname -s
+	// -s, --short
+	// Display the short host name. This is the host name cut at the first dot.
+	hostname = strings.Split(hostname, ".")[0]
 	log.Println("Hostname not set in config, using system's hostname...succeeded: [", hostname, "]")
 
 	return hostname

--- a/query.go
+++ b/query.go
@@ -67,7 +67,7 @@ func query() {
 
 func Query() {
 	for {
-		go query()
+		query()
 
 		dur := time.Second * time.Duration(GetGeneralConfig().Hbs.Interval)
 		time.Sleep(dur)

--- a/rpc.go
+++ b/rpc.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"math"
 	"net/rpc"
-	"sync"
 	"time"
 
 	"github.com/Cepave/common/model"
@@ -12,7 +11,6 @@ import (
 )
 
 type SingleConnRpcClient struct {
-	sync.Mutex
 	rpcClient *rpc.Client
 	RpcServer string
 	Timeout   time.Duration
@@ -61,10 +59,6 @@ func (this *SingleConnRpcClient) insureConn() {
 }
 
 func (this *SingleConnRpcClient) Call(method string, args interface{}, reply interface{}) error {
-
-	this.Lock()
-	defer this.Unlock()
-
 	this.insureConn()
 
 	timeout := time.Duration(50 * time.Second)


### PR DESCRIPTION
There is no need for multiple instances of `query()` in the same time.

Note: Please merge this [PR](https://github.com/Cepave/nqm-agent/pull/9) first
