### PR TITLE
[OWL-698] Intervals of measurements are from `hbs` now

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ NQM is a module for [Open-Falcon](https://github.com/open-falcon/). It enables t
 
 *  `make`
 
-   Build the binary
+    Build the binary
 
 *  `make pack`
 
-   Pack the necessary files into a tarball for deployment
+    Pack the necessary files into a tarball for deployment
 
 *  `make clean`
 
-   Remove the tarball and the excutable binary file
+    Remove the tarball and the excutable binary file
 
 
 
@@ -52,27 +52,11 @@ You can modify `cfg.example.json` for creating your own configuration file:
 
 Here are the explanations of the fields:
 
-*  *agent* [**Required**]
+*   *agent* [**Required**]
 
-   *  *PushURL*
+    *  *PushURL*
 
-      The RESTful API URL where NQM agent pushes data to.
-
-   *  *fpingInterval*
-
-      The time interval (seconds) between two calls of fping probes.
-
-
-   *  *tcppingInterval*
-
-      The time interval (seconds) between two calls of tcpping probes.
-
-   *  *tcpconnInterval*
-
-      The time interval (seconds) between two calls of tcpconn probes.
-
-      ​
-
+       The RESTful API URL where NQM agent pushes data to.
 
 
 
@@ -85,8 +69,6 @@ Here are the explanations of the fields:
   * *Interval*
 
     The time interval (seconds) between two queries to *RPCServer*.
-
-
 
 
 * *hostname* [**Optional**]

--- a/cfg.example.json
+++ b/cfg.example.json
@@ -1,9 +1,6 @@
 {
 	"agent": {
-		"pushURL": "http://127.0.0.1:1988/v1/push",
-		"fpingInterval": 60,
-		"tcppingInterval": 60,
-		"tcpconnInterval": 60
+		"pushURL": "http://127.0.0.1:1988/v1/push"
 	},
 	"hbs": {
 		"RPCServer": "127.0.0.1:6030",

--- a/cfg.go
+++ b/cfg.go
@@ -113,9 +113,9 @@ func getIP() string {
 	ip, err := PublicIP()
 	if err != nil {
 		log.Println("IP not set in config, getting public IP...failed:", err)
+	} else {
+		log.Println("IP not set in config, getting public IP...succeeded: [", ip, "]")
 	}
-
-	log.Println("IP not set in config, getting public IP...succeeded: [", ip, "]")
 	return ip
 }
 
@@ -177,6 +177,8 @@ func InitGeneralConfig(cfgFilePath string) {
 	cfg.Hbs = getJSONConfig().Hbs
 	cfg.hbsResp.Store(model.NqmTaskResponse{})
 	cfg.Hostname = getHostname()
-	cfg.IPAddress = getIP()
+	if cfg.IPAddress = getIP(); cfg.IPAddress == "UNKNOWN" {
+		log.Fatalln("IP can't be \"UNKNOWN\"")
+	}
 	cfg.ConnectionID = getConnectionID()
 }

--- a/cfg.go
+++ b/cfg.go
@@ -15,21 +15,13 @@ import (
 	"github.com/toolkits/file"
 )
 
-type MeasurementsProperty struct {
-	interval time.Duration
-	enabled  bool
-}
-
 type AgentConfig struct {
-	PushURL         string `json:"pushURL"`
-	FpingInterval   int    `json:"fpingInterval"`
-	TcppingInterval int    `json:"tcppingInterval"`
-	TcpconnInterval int    `json:"tcpconnInterval"`
+	PushURL string `json:"pushURL"`
 }
 
 type HbsConfig struct {
-	RPCServer string `json:"RPCServer"`
-	Interval  int    `json:"interval"`
+	RPCServer string        `json:"RPCServer"`
+	Interval  time.Duration `json:"interval"`
 }
 
 type JSONConfigFile struct {
@@ -42,11 +34,10 @@ type JSONConfigFile struct {
 
 type GeneralConfig struct {
 	JSONConfigFile
-	hbsResp      atomic.Value // for receiving model.NqmPingTaskResponse
+	hbsResp      atomic.Value // for receiving model.NqmTaskResponse
 	Hostname     string
 	IPAddress    string
 	ConnectionID string
-	Measurements map[string]MeasurementsProperty
 }
 
 var (
@@ -54,14 +45,6 @@ var (
 	generalConfig *GeneralConfig
 	jsonCfgLock   = new(sync.RWMutex)
 )
-
-func NewMeasurements() map[string]MeasurementsProperty {
-	return map[string]MeasurementsProperty{
-		"fping":   {time.Duration(GetGeneralConfig().Agent.FpingInterval), false},
-		"tcpping": {time.Duration(GetGeneralConfig().Agent.TcppingInterval), false},
-		"tcpconn": {time.Duration(GetGeneralConfig().Agent.TcpconnInterval), false},
-	}
-}
 
 func getBinAbsPath() string {
 	bin, err := filepath.Abs(os.Args[0])
@@ -192,9 +175,8 @@ func InitGeneralConfig(cfgFilePath string) {
 	loadJSONConfig(cfgFilePath)
 	cfg.Agent = getJSONConfig().Agent
 	cfg.Hbs = getJSONConfig().Hbs
-	cfg.hbsResp.Store(model.NqmPingTaskResponse{})
+	cfg.hbsResp.Store(model.NqmTaskResponse{})
 	cfg.Hostname = getHostname()
 	cfg.IPAddress = getIP()
 	cfg.ConnectionID = getConnectionID()
-	cfg.Measurements = NewMeasurements()
 }

--- a/marshal.go
+++ b/marshal.go
@@ -113,10 +113,9 @@ func marshalJSONToGraph(target model.NqmTarget, agent model.NqmAgent, metric str
 	return ParamToAgent{metric, endpoint, value, counterType, tags, timestamp, step}
 }
 
-func marshalStatsRow(row map[string]string, target model.NqmTarget, agent model.NqmAgent, u Utility) []ParamToAgent {
+func marshalStatsRow(row map[string]string, target model.NqmTarget, agent model.NqmAgent, step int64, u Utility) []ParamToAgent {
 	var params []ParamToAgent
 
-	step := int64(GetGeneralConfig().hbsResp.Load().(model.NqmTaskResponse).Measurements[u.UtilName()].Interval)
 	params = append(params, u.MarshalJSONParamsToGraph(target, agent, row, step)...)
 
 	t := convToNqmTarget(target)
@@ -127,12 +126,12 @@ func marshalStatsRow(row map[string]string, target model.NqmTarget, agent model.
 	return params
 }
 
-func Marshal(statsData []map[string]string, u Utility, targets []model.NqmTarget, agent model.NqmAgent) []ParamToAgent {
+func Marshal(statsData []map[string]string, u Utility, targets []model.NqmTarget, agent model.NqmAgent, step int64) []ParamToAgent {
 	var params []ParamToAgent
 
 	for rowIdx, statsRow := range statsData {
 		target := targets[rowIdx]
-		params = append(params, marshalStatsRow(statsRow, target, agent, u)...)
+		params = append(params, marshalStatsRow(statsRow, target, agent, step, u)...)
 	}
 	return params
 }

--- a/measure.go
+++ b/measure.go
@@ -11,7 +11,7 @@ import (
 
 type Utility interface {
 	CalcStats(row []float64, length int) map[string]string
-	MarshalJSONParamsToGraph(target model.NqmTarget, agent model.NqmAgent, row map[string]string) []ParamToAgent
+	MarshalJSONParamsToGraph(target model.NqmTarget, agent model.NqmAgent, row map[string]string, step int64) []ParamToAgent
 	ProbingCommand(command []string, targetAddressList []string) []string
 	UtilName() string
 	Interval() time.Duration
@@ -21,12 +21,12 @@ type Fping struct {
 	Utility
 }
 
-func (u *Fping) MarshalJSONParamsToGraph(target model.NqmTarget, agent model.NqmAgent, row map[string]string) []ParamToAgent {
+func (u *Fping) MarshalJSONParamsToGraph(target model.NqmTarget, agent model.NqmAgent, row map[string]string, step int64) []ParamToAgent {
 	var params []ParamToAgent
 
-	params = append(params, marshalJSONToGraph(target, agent, "packets-sent", row["pkttransmit"]))
-	params = append(params, marshalJSONToGraph(target, agent, "packets-received", row["pktreceive"]))
-	params = append(params, marshalJSONToGraph(target, agent, "transmission-time", row["rttavg"]))
+	params = append(params, marshalJSONToGraph(target, agent, "packets-sent", row["pkttransmit"], step))
+	params = append(params, marshalJSONToGraph(target, agent, "packets-received", row["pktreceive"], step))
+	params = append(params, marshalJSONToGraph(target, agent, "transmission-time", row["rttavg"], step))
 
 	return params
 }
@@ -79,8 +79,8 @@ type Tcpping struct {
 	Utility
 }
 
-func (u *Tcpping) MarshalJSONParamsToGraph(target model.NqmTarget, agent model.NqmAgent, row map[string]string) []ParamToAgent {
-	return new(Fping).MarshalJSONParamsToGraph(target, agent, row)
+func (u *Tcpping) MarshalJSONParamsToGraph(target model.NqmTarget, agent model.NqmAgent, row map[string]string, step int64) []ParamToAgent {
+	return new(Fping).MarshalJSONParamsToGraph(target, agent, row, step)
 }
 
 func (u *Tcpping) ProbingCommand(command []string, targetAddressList []string) []string {
@@ -104,9 +104,9 @@ type Tcpconn struct {
 	Utility
 }
 
-func (u *Tcpconn) MarshalJSONParamsToGraph(target model.NqmTarget, agent model.NqmAgent, row map[string]string) []ParamToAgent {
+func (u *Tcpconn) MarshalJSONParamsToGraph(target model.NqmTarget, agent model.NqmAgent, row map[string]string, step int64) []ParamToAgent {
 	var params []ParamToAgent
-	params = append(params, marshalJSONToGraph(target, agent, "tcpconn", row["time"]))
+	params = append(params, marshalJSONToGraph(target, agent, "tcpconn", row["time"], step))
 	return params
 }
 

--- a/probe.go
+++ b/probe.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-func trimResults(fpingResults []string) []string {
+func trimResults(results []string) []string {
 	var trimmedData []string
-	for _, result := range fpingResults {
+	for _, result := range results {
 		if strings.HasPrefix(result, "ICMP Time Exceeded from") {
 			continue
 		}
@@ -24,8 +24,8 @@ func Probe(probingCmd []string, util string) []string {
 		// one target with 100% packet loss.
 		log.Println("[", util, "] An error occured:", err)
 	}
-	fpingResults := strings.Split(string(cmdOutput), "\n")
-	fpingResults = fpingResults[:len(fpingResults)-1]
-	rawData := trimResults(fpingResults)
+	results := strings.Split(string(cmdOutput), "\n")
+	results = results[:len(results)-1]
+	rawData := trimResults(results)
 	return rawData
 }

--- a/query_test.go
+++ b/query_test.go
@@ -4,63 +4,29 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/Cepave/common/model"
 )
 
-func TestUpdateMeasurements(t *testing.T) {
-	var cfg GeneralConfig
-	generalConfig = &cfg
-	cfg.Agent = new(AgentConfig)
-	cfg.Agent.FpingInterval = 60
-	cfg.Agent.TcppingInterval = 60
-	cfg.Agent.TcpconnInterval = 60
-
-	tests := [][]string{
-		{"", "", ""},
-		{"", "", "tcpconn"},
-		{"", "tcpping", ""},
-		{"", "tcpping", "tcpconn"},
-		{"fping", "", ""},
-		{"fping", "", "tcpconn"},
-		{"fping", "tcpping", ""},
-		{"fping", "tcpping", "tcpconn"},
-	}
-
-	expecteds := []map[string]MeasurementsProperty{
-		{"fping": {60, false}, "tcpping": {60, false}, "tcpconn": {60, false}},
-		{"fping": {60, false}, "tcpping": {60, false}, "tcpconn": {60, true}},
-		{"fping": {60, false}, "tcpping": {60, true}, "tcpconn": {60, false}},
-		{"fping": {60, false}, "tcpping": {60, true}, "tcpconn": {60, true}},
-		{"fping": {60, true}, "tcpping": {60, false}, "tcpconn": {60, false}},
-		{"fping": {60, true}, "tcpping": {60, false}, "tcpconn": {60, true}},
-		{"fping": {60, true}, "tcpping": {60, true}, "tcpconn": {60, false}},
-		{"fping": {60, true}, "tcpping": {60, true}, "tcpconn": {60, true}},
-	}
-
-	for j, c := range tests {
-		d := updateMeasurements(c)
-		if !reflect.DeepEqual(expecteds[j], d) {
-			t.Error(expecteds[j], d)
-		}
-		t.Log(expecteds[j], d)
-
-	}
-}
-
 func TestUpdatedMsg(t *testing.T) {
-	testsOld := []map[string]MeasurementsProperty{
-		{"fping": {60, true}, "tcpping": {60, true}, "tcpconn": {60, true}},
-		{"fping": {60, false}, "tcpping": {60, false}, "tcpconn": {60, false}},
-		{"fping": {60, true}, "tcpping": {60, false}, "tcpconn": {60, true}},
-		{"fping": {60, true}, "tcpping": {60, false}, "tcpconn": {60, false}},
-		{"fping": {60, false}, "tcpping": {60, true}, "tcpconn": {60, false}},
+	testsOld := []map[string]model.MeasurementsProperty{
+		{"fping": {true, []string{""}, 60}, "tcpping": {true, []string{""}, 60}, "tcpconn": {true, []string{""}, 60}},
+		{"fping": {false, []string{""}, 60}, "tcpping": {false, []string{""}, 60}, "tcpconn": {false, []string{""}, 60}},
+		{"fping": {true, []string{""}, 60}, "tcpping": {false, []string{""}, 60}, "tcpconn": {true, []string{""}, 60}},
+		{"fping": {true, []string{""}, 60}, "tcpping": {false, []string{""}, 60}, "tcpconn": {false, []string{""}, 60}},
+		{"fping": {false, []string{""}, 60}, "tcpping": {true, []string{""}, 60}, "tcpconn": {false, []string{""}, 60}},
+		{"fping": {false, []string{""}, 60}, "tcpping": {true, []string{""}, 60}, "tcpconn": {true, []string{""}, 60}},
+		nil,
 	}
 
-	testsUpdated := []map[string]MeasurementsProperty{
-		{"fping": {60, false}, "tcpping": {60, false}, "tcpconn": {60, false}},
-		{"fping": {60, true}, "tcpping": {60, true}, "tcpconn": {60, true}},
-		{"fping": {60, false}, "tcpping": {60, false}, "tcpconn": {60, true}},
-		{"fping": {60, false}, "tcpping": {60, false}, "tcpconn": {60, true}},
-		{"fping": {60, false}, "tcpping": {60, true}, "tcpconn": {60, false}},
+	testsUpdated := []map[string]model.MeasurementsProperty{
+		{"fping": {false, []string{""}, 60}, "tcpping": {false, []string{""}, 60}, "tcpconn": {false, []string{""}, 60}},
+		{"fping": {true, []string{""}, 60}, "tcpping": {true, []string{""}, 60}, "tcpconn": {true, []string{""}, 60}},
+		{"fping": {false, []string{""}, 60}, "tcpping": {false, []string{""}, 60}, "tcpconn": {true, []string{""}, 60}},
+		{"fping": {false, []string{""}, 60}, "tcpping": {false, []string{""}, 60}, "tcpconn": {true, []string{""}, 60}},
+		{"fping": {false, []string{""}, 60}, "tcpping": {true, []string{""}, 60}, "tcpconn": {false, []string{""}, 60}},
+		nil,
+		{"fping": {true, []string{""}, 60}, "tcpping": {true, []string{""}, 60}, "tcpconn": {false, []string{""}, 60}},
 	}
 
 	expecteds := []string{
@@ -69,6 +35,8 @@ func TestUpdatedMsg(t *testing.T) {
 		"<fping Disabled> ",
 		"<fping Disabled> <tcpconn Enabled> ",
 		"",
+		"<tcpping Disabled> <tcpconn Disabled> ",
+		"<fping Enabled> <tcpping Enabled> ",
 	}
 
 	for i, _ := range testsOld {

--- a/rpc.go
+++ b/rpc.go
@@ -17,7 +17,7 @@ type SingleConnRpcClient struct {
 }
 
 var (
-	req       model.NqmPingTaskRequest
+	req       model.NqmTaskRequest
 	rpcClient SingleConnRpcClient
 )
 
@@ -85,7 +85,7 @@ func (this *SingleConnRpcClient) Call(method string, args interface{}, reply int
 
 func InitRPC() {
 	rpcClient.RpcServer = GetGeneralConfig().Hbs.RPCServer
-	req = model.NqmPingTaskRequest{
+	req = model.NqmTaskRequest{
 		Hostname:     GetGeneralConfig().Hostname,
 		IpAddress:    GetGeneralConfig().IPAddress,
 		ConnectionId: GetGeneralConfig().ConnectionID,

--- a/task.go
+++ b/task.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Cepave/common/model"
 )
@@ -14,20 +15,21 @@ func getTargetAddressList(targets []model.NqmTarget) []string {
 	return targetAddressList
 }
 
-func Task(u Utility) ([]string, []model.NqmTarget, model.NqmAgent, error) {
+func Task(u Utility) ([]string, []model.NqmTarget, model.NqmAgent, time.Duration, error) {
 	/**
 	 * Only 2 possible responses come from hbs:
 	 *     1. NeedPing==false (default condition)
-	 *         NqmAgent, NQMTargets, Command are nil
+	 *         NqmAgent, NQMTargets, Measurements are nil
 	 *     2. NeedPing==ture
-	 *         NqmAgent, NQMTargets, Command are not nil
+	 *         NqmAgent, NQMTargets, Measurements are not nil
 	 */
-	hbsResp := GetGeneralConfig().hbsResp.Load().(model.NqmPingTaskResponse)
+	hbsResp := GetGeneralConfig().hbsResp.Load().(model.NqmTaskResponse)
+
 	if !hbsResp.NeedPing {
-		return nil, nil, model.NqmAgent{}, fmt.Errorf("[ " + u.UtilName() + " ] No tasks assigned.")
+		return nil, nil, model.NqmAgent{}, GetGeneralConfig().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] No tasks assigned.")
 	}
-	if !GetGeneralConfig().Measurements[u.UtilName()].enabled {
-		return nil, nil, model.NqmAgent{}, fmt.Errorf("[ " + u.UtilName() + " ] Not enabled.")
+	if !hbsResp.Measurements[u.UtilName()].Enabled {
+		return nil, nil, model.NqmAgent{}, GetGeneralConfig().Hbs.Interval, fmt.Errorf("[ " + u.UtilName() + " ] Not enabled.")
 
 	}
 	targets := make([]model.NqmTarget, len(hbsResp.Targets))
@@ -35,10 +37,10 @@ func Task(u Utility) ([]string, []model.NqmTarget, model.NqmAgent, error) {
 
 	agent := *hbsResp.Agent
 
-	command := make([]string, len(hbsResp.Command))
-	copy(command, hbsResp.Command)
+	command := make([]string, len(hbsResp.Measurements[u.UtilName()].Command))
+	copy(command, hbsResp.Measurements[u.UtilName()].Command)
 
 	targetAddressList := getTargetAddressList(targets)
 	probingCmd := u.ProbingCommand(command, targetAddressList)
-	return probingCmd, targets, agent, nil
+	return probingCmd, targets, agent, hbsResp.Measurements[u.UtilName()].Interval, nil
 }


### PR DESCRIPTION
In this PR, the cfg.json is not supporting the fields of setting the intervals of `fping`, `tcpping`, `tcpconn`. Instead, it takes correlative information from `hbs`'s responses. Also, different intervals of measurements make different `step` value in the JSON parameters now.
